### PR TITLE
Adding disable coloring instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ config :dc_metrics,
   pubsub_topic_name: "topic_name"
 ```
 
+By default, Elixir's Logger will print colored logs, which doesn't work on GCP. To prevent it
+
+```elixir
+config :logger, 
+  :console, colors: [enabled: false]
+```
+
 Then, to log an event
 
 ```elixir


### PR DESCRIPTION
This PR adds instructions on README to disable Elixir's Logger default coloring on GCP, which causes a weird `[0m` padding on all logs, causing GCP to not recognize it as a structured logging.