### PR TITLE
Adding disabled config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package can be installed by adding `dc_metrics` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:dc_metrics, "~> 0.1.0"}
+    {:dc_metrics, "~> 0.1.2"}
   ]
 end
 ```
@@ -86,4 +86,7 @@ fields and its descriptions can be found at the Confluence documentation page.
 
 * `:env` - environment of the application `(:prod, :staging, :sandbox, :dev, or :test)`. Usually you'll want to set 
 this as `Mix.env()`.
+
+* `:disabled` - When `true` the libs behaviour is completely disabled. This can be very useful for preventing logs on 
+test environments.
 

--- a/lib/dc_metrics.ex
+++ b/lib/dc_metrics.ex
@@ -40,7 +40,7 @@ defmodule DCMetrics do
   """
   @spec log(level, message, metadata) :: :ok
   def log(level, message, metadata) when level in @log_levels do
-    unless disabled? do
+    unless disabled?() do
       base_model = build_base_model(level, message, metadata)
 
       log_to_stdout(base_model)

--- a/lib/dc_metrics.ex
+++ b/lib/dc_metrics.ex
@@ -42,8 +42,10 @@ defmodule DCMetrics do
   def log(level, message, metadata) when level in @log_levels do
     base_model = build_base_model(level, message, metadata)
 
-    log_to_stdout(base_model)
-    log_to_metrics(base_model)
+    unless disabled? do
+      log_to_stdout(base_model)
+      log_to_metrics(base_model)
+    end
 
     :ok
   end
@@ -177,5 +179,9 @@ defmodule DCMetrics do
 
   defp pubsub_topic_name do
     Application.fetch_env!(:dc_metrics, :pubsub_topic_name)
+  end
+
+  def disabled? do
+    Application.get_env(:dc_metrics, :disabled, false)
   end
 end

--- a/lib/dc_metrics.ex
+++ b/lib/dc_metrics.ex
@@ -40,9 +40,9 @@ defmodule DCMetrics do
   """
   @spec log(level, message, metadata) :: :ok
   def log(level, message, metadata) when level in @log_levels do
-    base_model = build_base_model(level, message, metadata)
-
     unless disabled? do
+      base_model = build_base_model(level, message, metadata)
+
       log_to_stdout(base_model)
       log_to_metrics(base_model)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DCMetrics.MixProject do
   def project do
     [
       app: :dc_metrics,
-      version: "0.1.1",
+      version: "0.1.2",
       description: description(),
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR implements a new config `disabled` that, when set to `true`, completely disables the libs functionality. This can be very useful for preventing logs on test environments.